### PR TITLE
Update yanked version of fpm

### DIFF
--- a/recipes/rhel.rb
+++ b/recipes/rhel.rb
@@ -24,7 +24,7 @@ include_recipe 'nodejs'
 gem_package 'fpm' do
   gem_binary '/opt/chef/embedded/bin/gem'
   action :nothing
-  version '0.4.33'
+  version '0.4.42'
 end.run_action(:install)
 
 Gem.clear_paths


### PR DESCRIPTION
Updated to the latest v0.4.x version of fpm gem 

From https://rubygems.org/gems/fpm/versions...
"0.4.33 - April 9, 2013 (49 KB) yanked"