### PR TITLE
bump package version to match the statsd project release tag

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 default['statsd']['port'] = 8125
 default['statsd']['graphite_port'] = 2003
 default['statsd']['graphite_host'] = 'localhost'
-default['statsd']['package_version'] = '0.6.0'
+default['statsd']['package_version'] = '0.8.0'
 default['statsd']['sha'] = '972993ef59c34ab92883bc62271efbc90514dde3'
 default['statsd']['user'] = 'statsd'
 default['statsd']['repo'] = 'https://github.com/etsy/statsd.git'


### PR DESCRIPTION
This should be a major version change in the cookbook, to simplify the upgrade process of downstream.