### PR TITLE
adding missing directory that upstart script will be put into

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -17,6 +17,12 @@
 # limitations under the License.
 #
 
+directory '/usr/share/statsd/scripts' do
+  mode 0o755
+  recursive true
+  action :create
+end
+
 cookbook_file '/usr/share/statsd/scripts/start' do
   source 'upstart.start'
   mode 0o755


### PR DESCRIPTION
After the package is installed we drop a file into `/usr/share/stasd/scripts` for upstart but this directory does not exist which leads to a failed convergence:
```
       Recipe: statsd::service
         * cookbook_file[/usr/share/statsd/scripts/start] action create
           * Parent directory /usr/share/statsd/scripts does not exist.
           ================================================================================
           Error executing action `create` on resource 'cookbook_file[/usr/share/statsd/scripts/start]'
           ================================================================================
           
           Chef::Exceptions::EnclosingDirectoryDoesNotExist
           ------------------------------------------------
           Parent directory /usr/share/statsd/scripts does not exist.
           
           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cache/cookbooks/statsd/recipes/service.rb
           
            20: cookbook_file '/usr/share/statsd/scripts/start' do
            21:   source 'upstart.start'
            22:   mode 0o755
            23: end
            24: 
           
           Compiled Resource:
           ------------------
           # Declared in /tmp/kitchen/cache/cookbooks/statsd/recipes/service.rb:20:in `from_file'
           
           cookbook_file("/usr/share/statsd/scripts/start") do
             action [:create]
             default_guard_interpreter :default
             declared_type :cookbook_file
             cookbook_name "statsd"
             recipe_name "service"
             source "upstart.start"
             mode 493
             path "/usr/share/statsd/scripts/start"
             owner nil
             group nil
             verifications []
           end
           
           System Info:
           ------------
           chef_version=13.8.5
           platform=ubuntu
           platform_version=14.04
           ruby=ruby 2.4.3p205 (2017-12-14 revision 61247) [x86_64-linux]
           program_name=chef-client worker: ppid=1855;start=23:20:53;
           executable=/opt/chef/bin/chef-client
           
       Recipe: statsd::debian
         * execute[build debian package] action run (up to date)
       Recipe: statsd::service
         * service[statsd] action restart
           - restart service service[statsd]
       
       Running handlers:
       [2018-04-16T23:21:40+00:00] ERROR: Running exception handlers
       Running handlers complete
       [2018-04-16T23:21:40+00:00] ERROR: Exception handlers complete
       Chef Client failed. 20 resources updated in 47 seconds
       [2018-04-16T23:21:40+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
       [2018-04-16T23:21:40+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
       [2018-04-16T23:21:40+00:00] ERROR: cookbook_file[/usr/share/statsd/scripts/start] (statsd::service line 20) had an error: Chef::Exceptions::EnclosingDirectoryDoesNotExist: Parent directory /usr/share/statsd/scripts does not exist.
       [2018-04-16T23:21:40+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Converge failed on instance <default-ubuntu-1404>.  Please see .kitchen/logs/default-ubuntu-1404.log for more details
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

It successfully converges after using this patch


Signed-off-by: Ben Abrams me@benabrams.it